### PR TITLE
Default to PHP 7.1.

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -5,7 +5,7 @@
 name: app
 
 # The runtime the application uses.
-type: "php:7.0"
+type: "php:7.1"
 
 # Configuration of the build of this application.
 build:


### PR DESCRIPTION
The Doctrine dependencies now require PHP 7.1.  Since Drupal is quite stable on 7.1 and we're defaulting to it for other examples we may as well do so here.