### PR TITLE
Use the correct web-root

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "extra": {
         "drupal-scaffold": {
             "locations": {
-                "web-root": "html/"
+                "web-root": "web/"
             }
         },
         "installer-types": [


### PR DESCRIPTION
During the upgrade to Open Social 10 in 5f03817a38aae58190f281d70490163e4f40b4d9
the scaffolding set-up was changed. In most of our internal projects we use `html` as web
root but in this Platform.sh example we use Platform.sh's default of `web`. A copy paste error
causes the scaffolding files to be placed in the wrong location which means platforms don't
work.