### PR TITLE
Readme updates, Platform settings/syntax fixes

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -5,11 +5,19 @@
 name: app
 
 # The runtime the application uses.
-type: "php:7.3"
+type: "php:7.4"
 
-# Configuration of the build of this application.
-build:
-    flavor: composer
+# The build-time dependencies of the app.
+dependencies:
+    php:
+        drush/drush: "^8.0"
+        drupal/console: "@stable"
+        composer/composer: '^2'
+
+runtime:
+    # Enable the redis extension so Drupal can communicate with the Redis cache.
+    extensions:
+        - redis
 
 # The build-time dependencies of the app.
 dependencies:
@@ -24,7 +32,65 @@ dependencies:
 relationships:
     database: "mysqldb:mysql"
 #    solr: "solrsearch:solr"
-#    redis: "rediscache:redis"
+    redis: 'cache:redis'
+
+# The size of the persistent disk of the application (in MB).
+disk: 2048
+
+# The mounts that will be performed when the package is deployed.
+mounts:
+    # The default Drupal files directory.
+    '/web/sites/default/files':
+        source: local
+        source_path: 'files'
+    # Drupal gets its own dedicated tmp directory. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/tmp':
+        source: local
+        source_path: 'tmp'
+    # Private file uploads are stored outside the web root. The settings.platformsh.php
+    # file will automatically configure Drupal to use this directory.
+    '/private':
+        source: local
+        source_path: 'private'
+    # Drush needs a scratch space for its own caches.
+    '/.drush':
+        source: local
+        source_path: 'drush'
+    # Drush will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/drush-backups':
+        source: local
+        source_path: 'drush-backups'
+    # Drupal Console will try to save backups to this directory, so it must be
+    # writeable even though you will almost never need to use it.
+    '/.console':
+        source: local
+        source_path: 'console'
+
+# Configuration of the build of this application.
+build:
+    # Automatically run `composer install` on every build.
+    flavor: composer
+
+# The hooks executed at various points in the lifecycle of the application.
+hooks:
+    # The build hook runs after Composer to finish preparing up your code.
+    # No services are available but the disk is writeable.
+    build: |
+        set -e
+    # The deploy hook runs after your application has been deployed and started.
+    # Code cannot be modified at this point but the database is available.
+    # The site is not accepting requests while this script runs so keep it
+    # fast.
+    deploy: |
+      set -e
+      php ./drush/platformsh_generate_drush_yml.php
+      cd web
+      drush -y cache-rebuild
+      drush -y updatedb
+      drush -y fra --bundle=social
+      drush -y entup
 
 # The configuration of app when it is exposed to the web.
 web:
@@ -59,6 +125,13 @@ web:
                 '^/sitemap\.xml$':
                     allow: true
 
+                # Deny direct access to configuration files.
+                '^/sites/sites\.php$':
+                    scripts: false
+                '^/sites/[^/]+/settings.*?\.php$':
+                    scripts: false
+
+        # The files directory has its own special configuration rules.
         '/sites/default/files':
             # Allow access to all files in the public files directory.
             allow: true
@@ -66,33 +139,13 @@ web:
             passthru: '/index.php'
             root: 'web/sites/default/files'
 
-            # Do not execute PHP scripts.
+            # Do not execute PHP scripts from the writeable mount.
             scripts: false
 
             rules:
                 # Provide a longer TTL (2 weeks) for aggregated CSS and JS files.
-                '^/sites/default/files/(css|jss)':
+                '^/sites/default/files/(css|js)':
                     expires: 2w
-
-# The size of the persistent disk of the application (in MB).
-disk: 2048
-
-# The mounts that will be performed when the package is deployed.
-mounts:
-    "/web/sites/default/files": "shared:files/files"
-    "/tmp": "shared:files/tmp"
-    "/private": "shared:files/private"
-
-# The hooks executed at various points in the lifecycle of the application.
-hooks:
-    # We run deploy hook after your application has been deployed and started.
-    # @TODO Re-import configuration
-    deploy: |
-      cd web
-      drush -y cache-rebuild
-      drush -y updatedb
-      drush -y fra --bundle=social
-      drush -y entup
 
 # The configuration of scheduled execution.
 # @TODO Add more crons to make sure the stream is up to date.

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -14,11 +14,6 @@ dependencies:
         drupal/console: "@stable"
         composer/composer: '^2'
 
-runtime:
-    # Enable the redis extension so Drupal can communicate with the Redis cache.
-    extensions:
-        - redis
-
 # The build-time dependencies of the app.
 dependencies:
     php:
@@ -32,7 +27,7 @@ dependencies:
 relationships:
     database: "mysqldb:mysql"
 #    solr: "solrsearch:solr"
-    redis: 'cache:redis'
+#    redis: 'cache:redis'
 
 # The size of the persistent disk of the application (in MB).
 disk: 2048

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -6,11 +6,6 @@
 "https://{default}/":
     type: upstream
     upstream: "app:http"
-    cache:
-      enabled: true
-
-      # Base the cache on the session cookie and custom Drupal cookies. Ignore all other cookies.
-      cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
 
 "https://www.{default}/":
     type: redirect

--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -3,10 +3,15 @@
 # Each route describes how an incoming URL is going
 # to be processed by Platform.sh.
 
-"http://{default}/":
+"https://{default}/":
     type: upstream
     upstream: "app:http"
+    cache:
+      enabled: true
 
-"http://www.{default}/":
+      # Base the cache on the session cookie and custom Drupal cookies. Ignore all other cookies.
+      cookies: ['/^SS?ESS/', '/^Drupal.visitor/']
+
+"https://www.{default}/":
     type: redirect
-    to: "http://{default}/"
+    to: "https://{default}/"

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -6,6 +6,3 @@
 mysqldb:
     type: "mysql:10.0"
     disk: 2048
-
-cache:
-    type: redis:6.0

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -6,10 +6,6 @@
 mysqldb:
     type: "mysql:10.0"
     disk: 2048
-#
-#rediscache:
-#    type: "redis:3.0"
-#
-#solrsearch:
-#    type: "solr:4.10"
-#    disk: 1024
+
+cache:
+    type: redis:6.0

--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,10 @@ How to use:
 3. Change the composer.json file to your liking.
     E.g. change open_social version or add new modules.
 
-4. Run composer install in this directory.
-
-5. Add everything to a new commit, including composer.lock.
+4. Commit the changes.
     ````
     git add .
-    git remote add platform [id]@git.[region].platform.sh:[id].git
+    git commit -m "Customizations"
     git push -u platform master
     ````
 

--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,19 @@ Template for the Open Social Platform.sh trials.
 
 How to use:
 
-1. Create a new project on Platform.sh
-    Configure the project by selecting a name and the necessary resources, etc.
-    Make sure to select that you want to import "an existing project".
-    You should see instructions to push existing code to platform.
+1. Clone this repository into a new directory and enter this directory.
+
+2. Create a new project on Platform.sh and choose "create from scratch"
+    Once the project is built, you'll see a step to [set Platform.sh as remote](https://docs.platform.sh/gettingstarted/introduction/own-code/create-project.html)
 
     ````
     git remote add platform [id]@git.[region].platform.sh:[id].git
-    git push -u platform master
     ````
-
-2. Clone this repository into a new directory and go to this directory.
+    
+    Or if you're using the Platform CLI:
+    ````
+    platform project:set-remote <project ID>
+    ````
 
 3. Change the composer.json file to your liking.
     E.g. change open_social version or add new modules.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Open Social Platform.sh trial!#
+# Open Social Platform.sh trial!
 
 Template for the Open Social Platform.sh trials.
 


### PR DESCRIPTION
The readme hadn't been updated in 5 years, and initially this was just some fixes to that because Platform.sh has changed significantly since then.

Along the way I realized Drush wasn't running on deploy (also because of Platform changes) so I updated `.platform.app.yaml` to match the current settings for [Platform's Drupal 8 template](https://github.com/platformsh-templates/drupal8) and modernized the settings in `.platform`

Edit: Removed Redis settings after I realized it wouldn't work with Open Social, at least in default config.